### PR TITLE
feat(merger): strategy-agnostic post-detection PAS-summit merger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,14 @@ reports/generate_figures_simple.py
 reports/generate_report.py
 reports/run_build_simple.sh
 reports/build_pdf.sh
+reports/build_latex.sh
 reports/subset_heavy_strategies.py
+# LaTeX source and build artefacts
+reports/PeakATail_Technical_Report.tex
+reports/*.aux
+reports/*.log
+reports/*.toc
+reports/*.out
 reports/explainer_figures.py
 reports/baseline_apa_completeness/
 reports/subset_curated.h5ad
@@ -79,6 +86,14 @@ reports/subset_length_compare/
 # Root-level report build helpers (invoke scripts inside reports/)
 run_build.sh
 run_generate_figures.sh
+
+# Performance report (local-only artefacts, same pattern as Technical Report)
+reports/PeakATail_Performance_Report.tex
+reports/PeakATail_Performance_Report.pdf
+reports/PeakATail_Performance_Report.md
+reports/perf_figures.py
+reports/build_perf.sh
+reports/figures/perf/
 
 # PR scratch (paste into GitHub — not for upstream)
 PR_DESCRIPTION.md

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -95,7 +95,7 @@ Options:
   --tile-size INTEGER             Tile size in bp (auto if unset).
   --tile-overlap INTEGER          Tile overlap in bp.  [default: 10000]
   --peak-strategy TEXT            Peak-calling strategy (run --list-strategies
-                                  to see).  [default: original]
+                                  to see).  [default: lambda_gradient]
   --lambda-window INTEGER         Background lambda estimation window (bp).
                                   [default: 5000]
   --lambda-method TEXT            Lambda estimator (median / mean / ...).
@@ -113,6 +113,20 @@ Options:
                                   threshold).  [default: 3]
   --pas-gap INTEGER               Minimum gap between PAS within a peak (bp).
                                   [default: 100]
+  --min-pas-spacing INTEGER       Tier-1 (distance) of the post-detection PAS
+                                  merger.  Adjacent PAS within one peak whose
+                                  gap is below this value are merged uncon-
+                                  ditionally.  -1 (default) auto-detects the
+                                  median read length per BAM; 0 disables the
+                                  distance tier.  [default: -1]
+  --min-pas-prominence FLOAT      Tier-2 (valley) static fallback for the
+                                  post-detection PAS merger.  Lambda strategies
+                                  (lambda_poisson, lambda_gradient) ignore
+                                  this and use their own compute_lambda(...).
+                                  Non-lambda strategies (original,
+                                  sierra_iterative) use this value as the
+                                  valley-depth threshold.  Negative disables
+                                  Tier 2.  [default: 5.0]
   --ip-filter                     Enable internal-priming filter (currently
                                   no-op).
   --genome-fasta PATH             Genome FASTA for --ip-filter (currently no-
@@ -212,7 +226,7 @@ Options:
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--peak-strategy` | TEXT | `original` | Algorithm used to call PAS peaks. Run `ema run --list-strategies` to see registered names. The `lambda_gradient` strategy has the highest precision in benchmark runs. |
+| `--peak-strategy` | TEXT | `lambda_gradient` | Algorithm used to call PAS peaks. Run `ema run --list-strategies` to see registered names. `lambda_gradient` is the recommended production strategy (highest precision in benchmark runs); pass `--peak-strategy original` for the unfiltered baseline. |
 | `--lambda-window` | INT | 5000 | Window size in bp used to estimate local background signal lambda. Increase for sparse data where the default window may include too few reads. |
 | `--lambda-method` | TEXT | `median` | Estimator for lambda within the window. `median` is robust to outliers; `mean` may be inflated by nearby peaks. |
 | `--lambda-fold-change` | FLOAT | 2.0 | A region must exceed `lambda * fold_change` to be called as a peak. Raise to 3.0–4.0 to reduce false positives in noisy data. |
@@ -222,6 +236,8 @@ Options:
 | `--dynamic-threshold` | FLAG | off | Use a per-window dynamic peak height threshold rather than a fixed cutoff. Useful for samples with highly variable library depth across chromosomes. |
 | `--floor-threshold` | INT | 3 | When `--dynamic-threshold` is on, this is the minimum peak height. Prevents the dynamic threshold from falling so low that noise is called. |
 | `--pas-gap` | INT | 100 | Minimum bp gap between two PAS within the same peak. Increase to merge closely-spaced PAS that likely represent the same site. |
+| `--min-pas-spacing` | INT | `-1` | Tier-1 (distance) of the post-detection PAS merger. Adjacent PAS within one peak whose gap < this value are merged unconditionally. `-1` auto-detects the median read length per BAM (e.g. ~98 bp for 10x v2, ~150 bp for v3). `0` disables Tier 1. See [Post-Detection PAS Merger](../strategies/pas-merger.md). |
+| `--min-pas-prominence` | FLOAT | `5.0` | Tier-2 (valley depth) of the post-detection PAS merger. Lambda strategies (`lambda_poisson`, `lambda_gradient`) **ignore** this value and use their own `compute_lambda(heights)` instead — fully dynamic. Non-lambda strategies (`original`, `sierra_iterative`) treat this as a static coverage-depth threshold. Negative disables Tier 2. |
 
 ### Filters
 

--- a/docs/strategies/.pages
+++ b/docs/strategies/.pages
@@ -1,6 +1,7 @@
 nav:
   - index.md
   - peak-calling.md
+  - pas-merger.md
   - clustering.md
   - quantification.md
   - diff.md

--- a/docs/strategies/pas-merger.md
+++ b/docs/strategies/pas-merger.md
@@ -1,0 +1,169 @@
+# Post-Detection PAS-Summit Merger
+
+A strategy-agnostic merge step that runs **after** every
+`strategy.find_pas(peak)` call, collapsing adjacent PAS regions that are too
+close together or share too shallow a valley to be biologically distinct.
+
+## Why this step exists
+
+The multi-PAS [peak-calling strategies](peak-calling.md)
+(`lambda_gradient`, `sierra_iterative`) produce one or more summit positions
+per peak, then split the peak's genomic span among them by midpoint cut. This
+split has two failure modes that no upstream knob catches:
+
+1. **Twin summits.** On low-coverage regions, the smoothed gradient can show
+   multiple shallow oscillations within a few base pairs. Each one clears the
+   per-summit prominence threshold individually and gets emitted, producing
+   pairs of PAS regions that differ by 1 bp at the partition boundary. No
+   single read can span across both — they are not biologically
+   distinguishable.
+2. **Shoulder peaks.** Two summits 20–80 bp apart with only a shallow dip
+   between them are emitted as separate PAS even when the valley sits at the
+   local Poisson background. These are one peak with a noisy double-top.
+
+Neither `--merge-len` (read-cluster grouping, upstream of any strategy) nor
+`--pas-gap` (cross-dataset BED merging, downstream of the full pipeline)
+addresses within-peak summit spacing. The post-detection merger fills that
+gap.
+
+## Two-tier design
+
+The merger lives in
+[`ema/countmatrix/peackcalling.py`](https://github.com/BMGLab/PeakATail/blob/develop/ema/countmatrix/peackcalling.py)
+and is wired into all three live execution paths (monolithic, pipeline,
+tile). Strategy-agnostic by construction — it operates on the
+`[(start, end), …]` contract that every strategy already returns.
+
+### Tier 1 — Distance gate
+
+```
+if next_region.start - prev_region.end < min_pas_spacing:
+    merge them
+```
+
+`min_pas_spacing` defaults to **`-1`** which triggers auto-detection of the
+median aligned read length from the BAM header (first 1,000 mapped reads).
+Two summits closer than one aligned read length cannot be resolved by any
+short-read library — a single read straddles both, so they must be the same
+PAS by construction.
+
+Typical auto-detected values:
+
+| Library | Auto-detected `min_pas_spacing` |
+|---|---|
+| 10x Chromium v2 | ~98 bp |
+| 10x Chromium v3 | ~91 bp |
+| Smart-seq2 | ~150 bp |
+| Long-read (Iso-Seq) | very large — Tier 2 dominates |
+
+Set `--min-pas-spacing 0` to disable Tier 1 (e.g. when you trust the
+strategy's own distance handling).
+
+### Tier 2 — Lambda-anchored valley
+
+If the gap passes Tier 1, the valley between the two regions is compared
+against a threshold supplied by the **strategy itself**:
+
+```python
+class PeakFinderStrategy:
+    def valley_threshold(self, peak, user_min_pas_prominence):
+        return user_min_pas_prominence   # base: static fallback
+
+class LambdaGradientStrategy(PeakFinderStrategy):
+    def valley_threshold(self, peak, _user):
+        return compute_lambda(           # override: dynamic, per-peak
+            [h for _, h in peak.peak_list],
+            method=self.lambda_method,
+            floor_fraction=self.floor_fraction,
+        )
+```
+
+- **Lambda strategies** (`lambda_poisson`, `lambda_gradient`) override to
+  return their own `compute_lambda(heights)` — the same background estimate
+  they use for the region significance gate. Fully dynamic; the user's
+  `--min-pas-prominence` is **ignored** for these strategies.
+- **Non-lambda strategies** (`original`, `sierra_iterative`) fall through to
+  the base implementation which returns `min_pas_prominence` unchanged. The
+  default value is `5.0` coverage units.
+
+The pair is merged when `valley_height < threshold`. Set
+`--min-pas-prominence -1` to disable Tier 2 regardless of strategy.
+
+## Reads in the merge gap are absorbed automatically
+
+The pipeline's `peak.cb_positions` dictionary is populated densely across
+the entire parent peak — every read end position contributes, not only
+summit positions. The next pipeline call after merging,
+`strategy.get_cb_dict_for_pas(peak, merged_start, merged_end)`, routes
+through `reconstruct_cb_dict` which slices `cb_positions` by **inclusive
+range**. Reads that fell in the gap between the two pre-merge regions are
+therefore added to the survivor's barcode counts without any explicit
+summing logic. The merger only needs to widen the genomic span; read
+absorption is a free consequence of how reconstruction already works.
+
+## Configuration
+
+| CLI flag | YAML key | Default | What 0/disabled means |
+|---|---|---|---|
+| `--min-pas-spacing N` | `min_pas_spacing: N` | `-1` (auto = median read length) | `0` disables Tier 1 |
+| `--min-pas-prominence X` | `min_pas_prominence: X` | `5.0` | `-1` (or any negative) disables Tier 2 |
+
+Combinations:
+
+```bash
+# Defaults: both tiers active (recommended)
+ema run --config example.yaml
+
+# Distance only — for strategies that already have good valley logic
+ema run --config example.yaml --min-pas-prominence -1
+
+# Prominence only — for libraries where you don't trust the read-length
+# auto-detect, but still want lambda-driven valley collapse
+ema run --config example.yaml --min-pas-spacing 0
+
+# Baseline (no merge at all) — exact pre-merger behaviour, for reproducibility
+ema run --config example.yaml --min-pas-spacing 0 --min-pas-prominence -1
+```
+
+## Wiring across execution paths
+
+The merger runs in all three live peak-calling code paths:
+
+- **Monolithic** (`peackcalling.py`, default sequential): 5 `find_pas` call
+  sites, each followed by a one-line `merge_close_or_low_prominence(…)`.
+- **Pipeline** (`peak_pipeline.py`, `--pipeline`): merger applied inside the
+  writer subprocess after every `find_pas`. Parameters passed at spawn time.
+- **Tile** (`tile_runner.py`, `--tiles`): each tile worker calls the
+  monolithic `peak_calling()` and inherits the merger automatically. Sentinel
+  resolution happens once at pool startup so tile workers don't re-scan the
+  BAM header.
+
+Equivalence between the monolithic and pipeline paths is verified on the
+chr22 test BAM with `lambda_gradient`: both produce bit-identical 252-PAS
+output.
+
+## Effect on the reference v9 dataset
+
+On SRR8325947 with `lambda_gradient` and default merger settings:
+
+| Metric | Before merger | After merger | Δ |
+|---|---|---|---|
+| Total PAS | 15,948 | 15,568 | −380 |
+| Same-strand pairs < 30 bp | 371 | **0** | −371 |
+| Filtered cells | 752 | 752 | 0 |
+| Leiden clusters | 11 | 11 | 0 |
+| Genes (classic length) | 1,925 | 1,898 | −27 |
+| Genes (proportion length) | 5,339 | 5,407 | +68 |
+| Genes (shannon entropy) | 5,339 | 5,407 | +68 |
+
+Counter-intuitively, the gene count for proportion/shannon length
+**increases** — when twin PAS whose narrow split-boundaries straddled a gene
+boundary are merged into one wider region, the merged region's overlap with
+a single gene becomes unambiguous and the gene becomes eligible for
+length-shift analysis.
+
+## See also
+
+- [Peak-Calling Strategies](peak-calling.md) — how PAS summits are produced upstream
+- [`ema run`](../cli/run.md) — `--min-pas-spacing` and `--min-pas-prominence` flags
+- [PeakATail Technical Report](https://github.com/BMGLab/PeakATail/blob/develop/reports/PeakATail_Technical_Report.pdf) — Section 5 covers the merger in depth

--- a/ema/cli/config_schema.py
+++ b/ema/cli/config_schema.py
@@ -336,7 +336,13 @@ class RunConfig:
 
     # ─── peak calling ────────────────────────────────────────────────────
     peak_strategy: str = field(
-        default="original",
+        # lambda_gradient is the recommended production strategy
+        # (40.6% precision @50bp on the benchmark; see technical report
+        # Sections 3 + 5).  `original` remains available as a baseline but
+        # is no longer the default — its lack of statistical filtering
+        # inflates PAS counts (~2x on the v9 BAM) and trips users who
+        # don't know to override.
+        default="lambda_gradient",
         metadata=_spec(
             cli_flag="--peak-strategy", yaml_key="peak_strategy",
             legacy_args_attr="strategy",
@@ -413,6 +419,36 @@ class RunConfig:
             cli_flag="--pas-gap", yaml_key="pas_gap",
             legacy_args_attr="pas_gap",
             description="Minimum gap between PAS within a peak (bp).",
+        ),
+    )
+    min_pas_spacing: int = field(
+        default=-1,
+        metadata=_spec(
+            cli_flag="--min-pas-spacing", yaml_key="min_pas_spacing",
+            legacy_dataclass_attr="variable_config.min_pas_spacing",
+            description=(
+                "Hard distance floor (bp) for the post-detection PAS merger. "
+                "Adjacent PAS within one peak whose gap is smaller than this "
+                "are merged unconditionally (Tier 1). "
+                "-1 (default) auto-detects median read length from each BAM. "
+                "0 disables the distance tier."
+            ),
+        ),
+    )
+    min_pas_prominence: float = field(
+        default=5.0,
+        metadata=_spec(
+            cli_flag="--min-pas-prominence", yaml_key="min_pas_prominence",
+            legacy_dataclass_attr="variable_config.min_pas_prominence",
+            click_type=click.FLOAT,
+            description=(
+                "Static valley-depth threshold for the Tier-2 post-detection "
+                "merger.  Used by NON-lambda strategies (original, "
+                "sierra_iterative).  Lambda strategies (lambda_poisson, "
+                "lambda_gradient) ignore this and use their own "
+                "compute_lambda(heights) as the threshold.  "
+                "Negative disables Tier 2 entirely.  Default 5.0."
+            ),
         ),
     )
 

--- a/ema/cli/switch_geneview.py
+++ b/ema/cli/switch_geneview.py
@@ -223,7 +223,9 @@ def geneview(ctx: click.Context, **kwargs) -> None:
         # ------------------------------------------------------------------ #
         from pathlib import Path
 
-        from ema.viz._gene_track_helpers import build_gene_panel, load_isoforms_for_gene
+        from ema.viz._gene_track_helpers import (
+            build_gene_panel, load_isoforms_for_gene, load_gene_name_from_gtf,
+        )
         from ema.viz import render_all
 
         figs_dir = out_dir / "figures"
@@ -238,8 +240,9 @@ def geneview(ctx: click.Context, **kwargs) -> None:
                 _gene_client = None
 
             for gene_id in gene_list:
-                # Optionally load isoform structure.
+                # Optionally load isoform structure + human-readable name.
                 isoforms = None
+                gene_name = ""
                 if kwargs.get("gtf"):
                     try:
                         isoforms = load_isoforms_for_gene(Path(kwargs["gtf"]), gene_id)
@@ -250,6 +253,14 @@ def geneview(ctx: click.Context, **kwargs) -> None:
                         log.warning(
                             "load_isoforms_for_gene failed for %s: %s", gene_id, exc
                         )
+                    try:
+                        gene_name = load_gene_name_from_gtf(
+                            Path(kwargs["gtf"]), gene_id
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            "load_gene_name_from_gtf failed for %s: %s", gene_id, exc
+                        )
 
                 panel = build_gene_panel(
                     gene_id=gene_id,
@@ -257,6 +268,7 @@ def geneview(ctx: click.Context, **kwargs) -> None:
                     pasbed=pasbed,
                     cluster_key=kwargs["cluster_key"],
                     isoforms=isoforms,
+                    gene_name=gene_name,
                 )
                 if panel is None:
                     log.warning(

--- a/ema/config.py
+++ b/ema/config.py
@@ -332,6 +332,21 @@ class variable_config:
     merge_len = 100
     ignore_chro = ["MT", "mt"]
     barcode_tag = args.barcode_tag
+    # Post-detection PAS-summit merger (strategy-agnostic; applied at the
+    # peak_calling caller layer after every strategy.find_pas() call).
+    # Tier 1: hard distance floor in bp.  -1 = auto-detect median read length
+    # per BAM; 0 disables the distance tier.
+    min_pas_spacing = -1
+    # Tier 2: static fallback valley threshold (coverage units) used by
+    # non-lambda strategies (original, sierra_iterative).  Lambda strategies
+    # ignore this and use compute_lambda(heights) instead.  Negative
+    # disables Tier 2 entirely.
+    min_pas_prominence = 5.0
+    # Cache populated once per BAM by peak_calling when min_pas_spacing == -1.
+    # Keyed by str(bam_path) -> int median read length.  Plain class-level
+    # dict (not a dataclass field) so it's accessible on the class itself,
+    # matching the access pattern variable_config.dataset_read_lengths.
+    dataset_read_lengths = {}
 
 @dataclass
 class filter_config:

--- a/ema/countmatrix/bam_utils.py
+++ b/ema/countmatrix/bam_utils.py
@@ -1,0 +1,41 @@
+"""Small BAM-inspection helpers used by the peak-calling driver."""
+from __future__ import annotations
+
+import pysam
+
+
+def infer_median_read_length(bam_path: str, n: int = 1000) -> int:
+    """Return the median read length detected from the first ``n`` reads of a BAM.
+
+    Used by the post-detection PAS merger to set its Tier-1 distance floor.
+    The default ``-1`` value of ``variable_config.min_pas_spacing`` triggers
+    this auto-detection once per BAM in ``ema/main.py``; the result is cached
+    in ``variable_config.dataset_read_lengths``.
+
+    Args:
+        bam_path: Absolute path to an indexed BAM file.
+        n: Maximum number of reads to sample.  Iterating the first ``n``
+            reads is effectively free even for very large BAMs.
+
+    Returns:
+        Median read length in base pairs.  Returns ``100`` as a safe
+        fallback when no read has a populated ``query_length`` (extremely
+        unusual but possible for header-only or hard-clipped BAMs).
+    """
+    bam = pysam.AlignmentFile(bam_path, "rb", threads=1)
+    lengths: list[int] = []
+    try:
+        for read in bam:
+            ql = read.query_length
+            if ql:
+                lengths.append(ql)
+                if len(lengths) >= n:
+                    break
+    finally:
+        bam.close()
+
+    if not lengths:
+        return 100
+
+    lengths.sort()
+    return lengths[len(lengths) // 2]

--- a/ema/countmatrix/peackcalling.py
+++ b/ema/countmatrix/peackcalling.py
@@ -9,6 +9,7 @@ from ema.countmatrix.peak_state import PeakCallingState
 from ema.countmatrix.read import read_check
 from ema.countmatrix.paswrite import matrix_write, pas_write
 from ema.config import directory_config, variable_config
+from ema.strategies.utils import merge_close_or_low_prominence
 from typing import TYPE_CHECKING
 
 log = logging.getLogger(__name__)
@@ -45,6 +46,13 @@ def peak_calling(
                     region: "tuple[str, int, int] | None" = None,
                     # --- per-chromosome progress reporting ---
                     progress_client=None,
+                    # --- Post-detection PAS merger (strategy-agnostic) ---
+                    # -1 (default) auto-detects median read length per BAM.
+                    # 0 disables the distance tier.  5.0 is the default
+                    # prominence floor (matching lambda_gradient's per-summit
+                    # default).  0.0 disables the prominence tier.
+                    min_pas_spacing: int = -1,
+                    min_pas_prominence: float = 5.0,
                 ):
 
     """Stream a BAM file and call peaks using a sliding coverage window.
@@ -144,6 +152,8 @@ def peak_calling(
             tile_overlap=tile_overlap,
             n_workers=n_workers,
             default_sample_id=default_sample_id,
+            min_pas_spacing=min_pas_spacing,
+            min_pas_prominence=min_pas_prominence,
         )
     # --- End tile dispatch ------------------------------------------------
 
@@ -183,6 +193,8 @@ def peak_calling(
             bam_threads=bam_threads,
             batch_size=batch_size,
             default_sample_id=_default_sample_id,
+            min_pas_spacing=min_pas_spacing,
+            min_pas_prominence=min_pas_prominence,
         )
     # --- End pipeline dispatch --------------------------------------------
 
@@ -228,6 +240,23 @@ def peak_calling(
     # use caller-specified bam_threads in full-scan mode.
     _open_threads = 1 if region is not None else bam_threads
     bamfile = ps.AlignmentFile(bamfile_dir, 'rb', threads=_open_threads)
+
+    # Resolve the auto-detect sentinel for the PAS merger distance tier:
+    # -1 means "infer median read length from this BAM, once, then cache".
+    # Cache lives in variable_config.dataset_read_lengths so every BAM is
+    # only inspected on its first peak_calling() invocation.
+    if min_pas_spacing < 0:
+        from ema.countmatrix.bam_utils import infer_median_read_length
+        _cache = variable_config.dataset_read_lengths
+        _key = str(bamfile_dir)
+        if _key not in _cache:
+            _cache[_key] = infer_median_read_length(_key)
+            log.info(
+                "Auto-detected median read length %d bp for %s "
+                "(min_pas_spacing distance tier)",
+                _cache[_key], bamfile_dir,
+            )
+        min_pas_spacing = _cache[_key]
     # Report total chromosomes to the progress bar (monolithic full-scan only).
     # `len(bamfile.references)` includes every reference in the BAM header —
     # for GRCh38 that's ~194 names with alts/decoys/HLA, most of which carry
@@ -277,6 +306,7 @@ def peak_calling(
             if signal:
 
                 pas_results = strategy.find_pas(peak)
+                pas_results = merge_close_or_low_prominence(pas_results, peak, strategy, min_pas_spacing, min_pas_prominence)
                 for pas_1, pas_2 in pas_results:
                     pasnumber = state.bump_pasnumber()
                     pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -286,6 +316,7 @@ def peak_calling(
             elif len(peak.peak_list) != 0:
 
                 pas_results = strategy.find_pas(peak)
+                pas_results = merge_close_or_low_prominence(pas_results, peak, strategy, min_pas_spacing, min_pas_prominence)
                 for pas_1, pas_2 in pas_results:
                     pasnumber = state.bump_pasnumber()
                     pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -353,6 +384,7 @@ def peak_calling(
                 #write pas
                 #make new instance of peak
                 pas_results = strategy.find_pas(peak)
+                pas_results = merge_close_or_low_prominence(pas_results, peak, strategy, min_pas_spacing, min_pas_prominence)
                 for pas_1, pas_2 in pas_results:
                     pasnumber = state.bump_pasnumber()
                     pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -370,6 +402,7 @@ def peak_calling(
     # Final flush for last chromosome — without this, the last peak is dropped
     if signal:
         pas_results = strategy.find_pas(peak)
+        pas_results = merge_close_or_low_prominence(pas_results, peak, strategy, min_pas_spacing, min_pas_prominence)
         for pas_1, pas_2 in pas_results:
             pasnumber = state.bump_pasnumber()
             pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -377,6 +410,7 @@ def peak_calling(
             matrix_write(pas_cb_dict, pasnumber, matrix, index=index)
     elif len(peak.peak_list) != 0:
         pas_results = strategy.find_pas(peak)
+        pas_results = merge_close_or_low_prominence(pas_results, peak, strategy, min_pas_spacing, min_pas_prominence)
         for pas_1, pas_2 in pas_results:
             pasnumber = state.bump_pasnumber()
             pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)

--- a/ema/countmatrix/peak_pipeline.py
+++ b/ema/countmatrix/peak_pipeline.py
@@ -71,6 +71,8 @@ def _flush_peak(
     strategy,
     bedfile,
     matrix,
+    min_pas_spacing: int = 0,
+    min_pas_prominence: float = 0.0,
 ) -> None:
     """Emit all PAS for *peak* to BED and MTX files.
 
@@ -90,8 +92,12 @@ def _flush_peak(
     """
     from ema.countmatrix.peak import Peak
     from ema.countmatrix.paswrite import pas_write, matrix_write
+    from ema.strategies.utils import merge_close_or_low_prominence
 
     pas_results = strategy.find_pas(peak)
+    pas_results = merge_close_or_low_prominence(
+        pas_results, peak, strategy, min_pas_spacing, min_pas_prominence,
+    )
     for pas_1, pas_2 in pas_results:
         Peak.pasnumber += 1
         pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -312,6 +318,8 @@ def writer_loop(
     bedfilepath: str,
     matrixpath: str,
     strategy_name: str,
+    min_pas_spacing: int = 0,
+    min_pas_prominence: float = 0.0,
 ) -> None:
     """Writer stage: consume peaks, run strategy, write BED and MTX.
 
@@ -328,6 +336,7 @@ def writer_loop(
     from ema.countmatrix.peak import Peak
     from ema.countmatrix.paswrite import pas_write, matrix_write
     from ema.strategies import get_strategy
+    from ema.strategies.utils import merge_close_or_low_prominence
 
     # Instantiate strategy locally (strategy objects may not be picklable)
     strategy = get_strategy(strategy_name)
@@ -349,6 +358,9 @@ def writer_loop(
                 continue
 
             pas_results = strategy.find_pas(peak)
+            pas_results = merge_close_or_low_prominence(
+                pas_results, peak, strategy, min_pas_spacing, min_pas_prominence,
+            )
             for pas_1, pas_2 in pas_results:
                 Peak.pasnumber += 1
                 pas_cb_dict = strategy.get_cb_dict_for_pas(peak, pas_1, pas_2)
@@ -384,6 +396,8 @@ def run_pipeline(
     batch_size: int = 10000,
     default_sample_id: str = "default",
     progress_client=None,
+    min_pas_spacing: int = -1,
+    min_pas_prominence: float = 5.0,
 ) -> None:
     """Run the 3-stage Reader → Finder → Writer pipeline.
 
@@ -425,6 +439,13 @@ def run_pipeline(
     Raises:
         RuntimeError: If any subprocess exits with a non-zero exit code.
     """
+    # Resolve auto-detect sentinel up front so the spawned writer subprocess
+    # receives a concrete value (subprocesses can't read variable_config's
+    # cache the spawned process has its own copy).
+    if min_pas_spacing < 0:
+        from ema.countmatrix.bam_utils import infer_median_read_length
+        min_pas_spacing = infer_median_read_length(bamfile_dir)
+
     ctx = mp.get_context("spawn")
 
     # Two bounded queues for backpressure
@@ -473,6 +494,8 @@ def run_pipeline(
             bedfilepath,
             matrixpath,
             strategy_name,
+            min_pas_spacing,
+            min_pas_prominence,
         ),
         daemon=True,
     )

--- a/ema/countmatrix/tile_runner.py
+++ b/ema/countmatrix/tile_runner.py
@@ -153,6 +153,11 @@ class JobSpec:
     lambda_window: int = 5000
     bam_threads: int = 4
     default_sample_id: str = "default"
+    # Post-detection PAS merger (strategy-agnostic).  -1 for spacing triggers
+    # auto-detect inside the spawned peak_calling; resolve before building
+    # JobSpec for best efficiency (single header scan instead of N workers).
+    min_pas_spacing: int = -1
+    min_pas_prominence: float = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +305,8 @@ def tile_worker(args: "dict[str, Any] | JobSpec") -> dict[str, Any]:
         _args_lambda_window = args.lambda_window
         _args_bam_threads = args.bam_threads
         _args_default_sample_id = args.default_sample_id
+        _args_min_pas_spacing = args.min_pas_spacing
+        _args_min_pas_prominence = args.min_pas_prominence
     else:
         tile_id = args["tile_id"]
         dataset_id = args.get("dataset_id", "default")
@@ -319,6 +326,8 @@ def tile_worker(args: "dict[str, Any] | JobSpec") -> dict[str, Any]:
         _args_lambda_window = args["lambda_window"]
         _args_bam_threads = args["bam_threads"]
         _args_default_sample_id = args["default_sample_id"]
+        _args_min_pas_spacing = args.get("min_pas_spacing", -1)
+        _args_min_pas_prominence = args.get("min_pas_prominence", 5.0)
 
     # Per-worker isolation: reset all process-global mutable state
     reset_index()
@@ -354,6 +363,8 @@ def tile_worker(args: "dict[str, Any] | JobSpec") -> dict[str, Any]:
             lambda_window=_args_lambda_window,
             bam_threads=_args_bam_threads,
             region=(chrom, fetch_start, fetch_end),
+            min_pas_spacing=_args_min_pas_spacing,
+            min_pas_prominence=_args_min_pas_prominence,
         )
 
         # ----------------------------------------------------------------
@@ -594,6 +605,8 @@ def build_job_specs(
     lambda_window: int = 5000,
     bam_threads: int = 4,
     per_bam_tile_sizes: dict[str, int] | None = None,
+    min_pas_spacing: int = -1,
+    min_pas_prominence: float = 5.0,
 ) -> list[JobSpec]:
     """Build a flat list of :class:`JobSpec` across all datasets × chroms × tiles × directions.
 
@@ -626,12 +639,19 @@ def build_job_specs(
     specs: list[JobSpec] = []
     job_id = 0
 
+    # Auto-detect resolution for ``min_pas_spacing < 0`` is performed lazily
+    # inside each spawned worker's :func:`peak_calling` call (which caches
+    # per-BAM in its own subprocess).  Doing it here would require opening
+    # every BAM at job-build time, which is wrong for callers that may build
+    # job specs before BAMs exist (e.g. unit tests with fake paths).
+
     for dataset_id, bam_path in bam_list:
         bam_tile_size = (
             per_bam_tile_sizes.get(str(bam_path), tile_size)
             if per_bam_tile_sizes
             else tile_size
         )
+        per_bam_spacing = min_pas_spacing
         chromosomes = get_chromosomes(str(bam_path))
         for chrom, length in chromosomes:
             tiles = split_chromosome_into_tiles(chrom, length, bam_tile_size, tile_overlap)
@@ -656,6 +676,8 @@ def build_job_specs(
                         lambda_window=lambda_window,
                         bam_threads=bam_threads,
                         default_sample_id=dataset_id,
+                        min_pas_spacing=per_bam_spacing,
+                        min_pas_prominence=min_pas_prominence,
                     ))
                     job_id += 1
 
@@ -789,6 +811,8 @@ def run_tiled(
     tile_overlap: int = 10_000,
     n_workers: int | None = None,
     default_sample_id: str = "default",
+    min_pas_spacing: int = -1,
+    min_pas_prominence: float = 5.0,
 ) -> None:
     """Run tile-parallel peak calling and merge results into final output files.
 
@@ -894,6 +918,8 @@ def run_tiled(
             lambda_fold_change=lambda_fold_change,
             lambda_window=lambda_window,
             bam_threads=bam_threads,
+            min_pas_spacing=min_pas_spacing,
+            min_pas_prominence=min_pas_prominence,
         )
         # Write CB list for consistency
         from ema.countmatrix.indexing import get_mapping
@@ -908,6 +934,17 @@ def run_tiled(
     # ----------------------------------------------------------------
     # Build worker arg dicts
     # ----------------------------------------------------------------
+    # Resolve auto-detect sentinel once for the whole pool before spawning
+    # workers — avoids N workers each scanning the BAM header for read length.
+    _resolved_spacing = min_pas_spacing
+    if _resolved_spacing < 0:
+        from ema.countmatrix.bam_utils import infer_median_read_length
+        _resolved_spacing = infer_median_read_length(bamfile_dir)
+        logger.info(
+            "run_tiled: auto-detected median read length %d bp for %s",
+            _resolved_spacing, bamfile_dir,
+        )
+
     worker_args: list[dict[str, Any]] = []
     for tile_id, (chrom, tile_start, tile_end, fetch_start, fetch_end) in enumerate(all_tiles):
         worker_args.append({
@@ -929,6 +966,8 @@ def run_tiled(
             "lambda_window": lambda_window,
             "bam_threads": bam_threads,
             "default_sample_id": default_sample_id,
+            "min_pas_spacing": _resolved_spacing,
+            "min_pas_prominence": min_pas_prominence,
         })
 
     # ----------------------------------------------------------------

--- a/ema/main.py
+++ b/ema/main.py
@@ -333,6 +333,13 @@ def _run_pipeline_body(progress=None, plot_engines: list[str] | None = None) -> 
         lambda_fold_change=args.lambda_fold_change,
         lambda_window=args.lambda_window,
         bam_threads=getattr(args, 'bam_threads', 4),
+        # Post-detection PAS merger (strategy-agnostic).
+        # -1 spacing triggers auto-detect (median read length per BAM) inside
+        # peak_calling / run_tiled / run_pipeline.  Prominence is the static
+        # fallback used by non-lambda strategies; lambda strategies override
+        # to compute_lambda(heights).
+        min_pas_spacing=variable_config.min_pas_spacing,
+        min_pas_prominence=variable_config.min_pas_prominence,
     )
 
     # Start GTF pre-processing in a background thread (with caching).
@@ -459,6 +466,8 @@ def _run_pipeline_body(progress=None, plot_engines: list[str] | None = None) -> 
             lambda_window=peak_kwargs.get("lambda_window", 5000),
             bam_threads=peak_kwargs.get("bam_threads", 4),
             per_bam_tile_sizes=per_bam_tile_sizes if _tile_size_is_auto else None,
+            min_pas_spacing=variable_config.min_pas_spacing,
+            min_pas_prominence=variable_config.min_pas_prominence,
         )
 
         log.info(

--- a/ema/strategies/base.py
+++ b/ema/strategies/base.py
@@ -44,3 +44,27 @@ class PeakFinderStrategy(ABC):
     def get_params(self) -> dict:
         """Return current strategy parameters for logging/benchmarking."""
         pass
+
+    def valley_threshold(self, peak, user_min_pas_prominence: float) -> float:
+        """Return the valley height below which two adjacent PAS should be merged.
+
+        Used by the post-detection PAS merger (Tier 2) to decide whether the
+        dip between two emitted summits is "background" — if the valley is
+        below this threshold the pair is merged.
+
+        Default implementation returns ``user_min_pas_prominence`` unchanged
+        — a static threshold supplied by the user.  Lambda-based strategies
+        (``lambda_poisson``, ``lambda_gradient``) override this to return
+        their own ``compute_lambda(heights)`` so the merger uses the same
+        dynamic background estimate the strategy itself uses for peak
+        significance.
+
+        Args:
+            peak: ``Peak`` instance providing ``peak_list``.
+            user_min_pas_prominence: Static fallback supplied from CLI/YAML.
+                Returned as-is by this base implementation.
+
+        Returns:
+            Valley height threshold in coverage units.
+        """
+        return float(user_min_pas_prominence)

--- a/ema/strategies/lambda_gradient.py
+++ b/ema/strategies/lambda_gradient.py
@@ -290,6 +290,25 @@ class LambdaGradientStrategy(PeakFinderStrategy):
         """
         return reconstruct_cb_dict(peak.cb_positions, pas_1, pas_2)
 
+    def valley_threshold(self, peak, user_min_pas_prominence: float) -> float:
+        """Return ``compute_lambda(heights)`` — the strategy's own background.
+
+        Overrides the static default in :class:`PeakFinderStrategy` so the
+        post-detection merger uses the same dynamic background estimate this
+        strategy uses for the region significance gate and per-PAS Poisson
+        tests.  The user-supplied ``min_pas_prominence`` is ignored for
+        lambda-based strategies — the valley test becomes "is the dip at or
+        below the local lambda?".
+        """
+        if not peak.peak_list:
+            return float(user_min_pas_prominence)
+        heights = [h for _, h in peak.peak_list]
+        return float(compute_lambda(
+            heights,
+            method=self.lambda_method,
+            floor_fraction=self.floor_fraction,
+        ))
+
     def get_params(self) -> dict:
         """Return the current parameter set for logging and benchmarking.
 

--- a/ema/strategies/lambda_poisson.py
+++ b/ema/strategies/lambda_poisson.py
@@ -121,6 +121,24 @@ class LambdaPoissonStrategy(PeakFinderStrategy):
         """
         return reconstruct_cb_dict(peak.cb_positions, pas_1, pas_2)
 
+    def valley_threshold(self, peak, user_min_pas_prominence: float) -> float:
+        """Return ``compute_lambda(heights)`` — the strategy's own background.
+
+        Overrides the static default in :class:`PeakFinderStrategy` so the
+        post-detection merger uses the same dynamic background estimate this
+        strategy uses for peak significance.  The user-supplied
+        ``min_pas_prominence`` is ignored for lambda-based strategies — the
+        valley test becomes "is the dip at or below the local lambda?".
+        """
+        if not peak.peak_list:
+            return float(user_min_pas_prominence)
+        heights = [h for _, h in peak.peak_list]
+        return float(compute_lambda(
+            heights,
+            method=self.lambda_method,
+            floor_fraction=self.floor_fraction,
+        ))
+
     def get_params(self) -> dict:
         """Return current strategy parameters for logging and benchmarking.
 

--- a/ema/strategies/utils.py
+++ b/ema/strategies/utils.py
@@ -1,6 +1,117 @@
 from typing import List, Tuple, Dict
 
 
+def merge_close_or_low_prominence(
+    regions: List[Tuple[int, int]],
+    peak,
+    strategy,
+    min_pas_spacing: int,
+    min_pas_prominence: float,
+) -> List[Tuple[int, int]]:
+    """Merge adjacent PAS regions whose summits are too close or share a shallow valley.
+
+    Strategy-agnostic post-detection merger.  Applied to ``find_pas`` output at
+    the caller layer (``peackcalling.py``) so every strategy benefits, including
+    future strategies whose contract is ``find_pas -> [(start, end), ...]``.
+
+    Two tiers, applied in order to each adjacent pair:
+
+    Tier 1 — Distance gate (hard floor):
+        If ``next.start - prev.end < min_pas_spacing``, the pair is merged
+        unconditionally.  Two summits within ~one read length are
+        biologically indistinguishable for short-read scRNA — one read can
+        straddle both, so they cannot be resolved as distinct PAS.
+
+    Tier 2 — Valley gate (per-strategy threshold):
+        If the gap passes Tier 1, the valley between the two regions is
+        compared against a threshold supplied by the strategy itself via
+        :meth:`~ema.strategies.base.PeakFinderStrategy.valley_threshold`:
+
+            - **Lambda-based strategies** (``lambda_poisson``,
+              ``lambda_gradient``) override the method to return their own
+              ``compute_lambda(heights)`` — fully dynamic, in lock-step with
+              whatever background the strategy uses for peak significance.
+              The user's ``min_pas_prominence`` is ignored for them.
+            - **Other strategies** (``original``, ``sierra_iterative``) fall
+              through to the base implementation which returns
+              ``min_pas_prominence`` unchanged — a static user-set threshold.
+
+        The pair is merged when ``valley < threshold``: the dip between the
+        candidates is not significantly above background.  Set
+        ``min_pas_prominence < 0`` to disable Tier 2 entirely.
+
+    Reads inside the gap are absorbed automatically: the next pipeline call
+    ``strategy.get_cb_dict_for_pas(peak, merged_start, merged_end)`` routes
+    through ``reconstruct_cb_dict``, which slices ``cb_positions`` by
+    inclusive range and picks up every position in the widened span.
+
+    Args:
+        regions: List of ``(start, end)`` tuples from ``find_pas``.
+        peak: ``Peak`` instance providing ``peak_list`` (list of
+            ``(position, height)``).
+        strategy: The strategy instance that produced ``regions``.  Its
+            :meth:`~ema.strategies.base.PeakFinderStrategy.valley_threshold`
+            decides whether Tier 2 uses a dynamic (lambda) or static
+            (user-set) valley threshold.
+        min_pas_spacing: Distance floor in bp.  Pairs with gap below this
+            value are always merged.  ``0`` disables the distance tier.
+        min_pas_prominence: Static fallback valley threshold passed to
+            ``strategy.valley_threshold`` for non-lambda strategies.
+            Lambda strategies ignore this value.  Negative disables Tier 2.
+
+    Returns:
+        List of merged ``(start, end)`` tuples sorted by genomic position.
+        Returns ``regions`` unchanged when it has 0 or 1 entries, or when
+        both tiers are disabled.
+    """
+    if len(regions) <= 1:
+        return regions
+
+    tier2_active = min_pas_prominence >= 0
+    tier1_active = min_pas_spacing > 0
+    if not tier1_active and not tier2_active:
+        return regions
+
+    regions = sorted(regions)
+    pos = [p for p, _ in peak.peak_list]
+    h = [hi for _, hi in peak.peak_list]
+
+    # Ask the strategy for the right threshold.  Lambda strategies return
+    # compute_lambda(heights); the base implementation returns the user's
+    # min_pas_prominence unchanged.
+    if tier2_active and strategy is not None:
+        threshold = strategy.valley_threshold(peak, min_pas_prominence)
+    else:
+        threshold = float(min_pas_prominence)
+
+    def _min_h_between(re: int, rs: int) -> int:
+        vals = [h[i] for i, p in enumerate(pos) if re < p < rs]
+        # No measured positions inside the gap → treat as zero-height valley
+        # (i.e. maximally deep) so an empty gap never forces a Tier-2 merge.
+        return min(vals) if vals else 0
+
+    merged: List[Tuple[int, int]] = [regions[0]]
+    for s, e in regions[1:]:
+        ps, pe = merged[-1]
+        gap = s - pe
+
+        # Tier 1: distance floor
+        if tier1_active and gap < min_pas_spacing:
+            merged[-1] = (ps, e)
+            continue
+
+        # Tier 2: valley vs threshold
+        if tier2_active:
+            valley = _min_h_between(pe, s)
+            if valley < threshold:
+                merged[-1] = (ps, e)
+                continue
+
+        merged.append((s, e))
+
+    return merged
+
+
 def partition_peak_region(summits: List[int], peak_positions: List[int]) -> List[Tuple[int, int]]:
     """Partition a peak region among multiple PAS by midpoint splitting.
 

--- a/ema/viz/_gene_track_helpers.py
+++ b/ema/viz/_gene_track_helpers.py
@@ -68,6 +68,12 @@ class GenePanel:
     # 1%-of-gene-span placeholder.
     pas_starts: list[int] = field(default_factory=list)
     pas_ends: list[int] = field(default_factory=list)
+    # Human-readable gene symbol from the GTF (e.g. "CLIC2", "DPYD").
+    # When available it's used in figure titles in front of the Ensembl ID
+    # so the reader sees ``CLIC2 (ENSG00000155962) — chrX:...`` instead of
+    # the opaque Ensembl identifier alone.  Empty when no GTF supplied or
+    # the gene wasn't found.
+    gene_name: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +133,7 @@ def build_gene_panel(
     cluster_key: str = "leiden",
     gene_id_col: str = "gene_id",
     isoforms: list[tuple[str, list[tuple[int, int]]]] | None = None,
+    gene_name: str = "",
 ) -> GenePanel | None:
     """Build a :class:`GenePanel` for one gene.
 
@@ -205,6 +212,7 @@ def build_gene_panel(
 
     return GenePanel(
         gene_id=str(gene_id),
+        gene_name=str(gene_name),
         chrom=chrom,
         start=g_start,
         end=g_end,
@@ -225,6 +233,42 @@ def build_gene_panel(
 # ---------------------------------------------------------------------------
 # Isoform structure helpers
 # ---------------------------------------------------------------------------
+
+def load_gene_name_from_gtf(gtf_path: Path, gene_id: str) -> str:
+    """Return the ``gene_name`` attribute for *gene_id* from the GTF (or '').
+
+    Streams the GTF, stopping at the first matching ``gene`` feature.  Used
+    to populate :attr:`GenePanel.gene_name` so figure titles can show a
+    human-readable symbol next to the Ensembl ID.
+
+    Args:
+        gtf_path: Path to a GTF annotation file.
+        gene_id: Ensembl gene ID to look up.
+
+    Returns:
+        The gene_name attribute, or ``""`` if not found / file unreadable.
+    """
+    needle = f'gene_id "{gene_id}"'
+    try:
+        with open(gtf_path) as fh:
+            for line in fh:
+                if line.startswith("#") or not line.strip():
+                    continue
+                if needle not in line:
+                    continue
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 9:
+                    continue
+                # Match in any line that references this gene_id; gene_name
+                # is identical across all rows for one gene so any hit
+                # suffices.
+                name = _gtf_attr(parts[8], "gene_name")
+                if name:
+                    return name
+    except OSError as exc:
+        log.warning("load_gene_name_from_gtf: could not read %s: %s", gtf_path, exc)
+    return ""
+
 
 def load_isoforms_for_gene(
     gtf_path: Path,

--- a/ema/viz/_gene_track_helpers.py
+++ b/ema/viz/_gene_track_helpers.py
@@ -61,6 +61,13 @@ class GenePanel:
     reads_per_cell: np.ndarray
     proportions: np.ndarray
     isoforms: list[tuple[str, list[tuple[int, int]]]] = field(default_factory=list)
+    # Actual genomic span of each PAS region (BED half-open).  Same length
+    # and order as ``pas_ids`` / ``pas_positions``.  When the merger widens
+    # a PAS, ``pas_ends - pas_starts`` reflects that.  The rendering layer
+    # uses these to draw bars at their real width rather than a fixed
+    # 1%-of-gene-span placeholder.
+    pas_starts: list[int] = field(default_factory=list)
+    pas_ends: list[int] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +166,9 @@ def build_gene_panel(
         return None
     # Re-derive pas_ids in coord-order so positions align with coverage cols.
     pas_ids = [int(p) for p in coords.index.tolist()]
-    pas_positions = [
-        int(((row["start"] + row["end"]) // 2)) for _, row in coords.iterrows()
-    ]
+    pas_starts = [int(row["start"]) for _, row in coords.iterrows()]
+    pas_ends = [int(row["end"]) for _, row in coords.iterrows()]
+    pas_positions = [(s + e) // 2 for s, e in zip(pas_starts, pas_ends)]
     chrom = str(coords["chrom"].iloc[0])
     strand = str(coords["strand"].iloc[0]) if "strand" in coords.columns else "+"
     g_start = int(coords["start"].min())
@@ -204,6 +211,8 @@ def build_gene_panel(
         strand=strand,
         pas_ids=pas_ids,
         pas_positions=pas_positions,
+        pas_starts=pas_starts,
+        pas_ends=pas_ends,
         clusters=clusters,
         n_cells_per_cluster=n_cells.tolist(),
         reads=reads,

--- a/ema/viz/gene_track_matplotlib.py
+++ b/ema/viz/gene_track_matplotlib.py
@@ -106,11 +106,24 @@ class GeneTrackMatplotlib(VizStrategy):
         has_structure = bool(panel.isoforms)
         n_isoforms = len(panel.isoforms) if has_structure else 0
 
-        # Shared x range with 5% padding on each side.
-        gene_span = max(panel.end - panel.start, 1)
+        # Shared x range: include BOTH the PAS coords (pasbed-derived) and
+        # the GTF isoform structure span so a gene whose exons extend
+        # outside the detected-PAS window still renders in full.  Without
+        # this, ``panel.start``/``panel.end`` came from pasbed only and
+        # exons could fall off-screen on the left or right side.
+        x_lo, x_hi = panel.start, panel.end
+        if panel.isoforms:
+            for _, exons in panel.isoforms:
+                if not exons:
+                    continue
+                ex_lo = min(s for s, _ in exons)
+                ex_hi = max(e for _, e in exons)
+                x_lo = min(x_lo, ex_lo)
+                x_hi = max(x_hi, ex_hi)
+        gene_span = max(x_hi - x_lo, 1)
         pad = int(gene_span * 0.05) + 1
-        x_min = panel.start - pad
-        x_max = panel.end + pad
+        x_min = x_lo - pad
+        x_max = x_hi + pad
 
         # Minimum visible bar width = 0.5% of gene span (so 1-bp PAS don't
         # disappear when the gene span is large).  Actual PAS widths from
@@ -241,8 +254,31 @@ class GeneTrackMatplotlib(VizStrategy):
             )
 
         # --- shared x-axis ---
+        # Format absolute genomic coordinates in human units (Mb / kb / bp)
+        # based on the gene span.  Without this matplotlib's auto-tick
+        # formatter renders e.g. ``9.7e+07`` for a chr-1 gene at ~97 Mb,
+        # which is hard to read and ambiguous (Mb? kb? bp?).
         bottom_ax = axes[-1]
-        bottom_ax.set_xlabel("Genomic position (bp)", fontsize=9)
+        if gene_span >= 1_000_000:
+            unit_label, unit_div = "Mb", 1_000_000
+            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
+                lambda x, _: f"{x / unit_div:,.2f}"
+            )
+        elif gene_span >= 1_000:
+            unit_label, unit_div = "kb", 1_000
+            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
+                lambda x, _: f"{x / unit_div:,.1f}"
+            )
+        else:
+            unit_label = "bp"
+            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
+                lambda x, _: f"{int(x):,}"
+            )
+        bottom_ax.xaxis.set_major_formatter(tick_fmt)
+        bottom_ax.set_xlabel(
+            f"Genomic position on chr{panel.chrom} ({unit_label})",
+            fontsize=9,
+        )
         bottom_ax.tick_params(axis="x", labelsize=7)
 
         # --- figure title ---

--- a/ema/viz/gene_track_matplotlib.py
+++ b/ema/viz/gene_track_matplotlib.py
@@ -254,40 +254,63 @@ class GeneTrackMatplotlib(VizStrategy):
             )
 
         # --- shared x-axis ---
-        # Format absolute genomic coordinates in human units (Mb / kb / bp)
-        # based on the gene span.  Without this matplotlib's auto-tick
-        # formatter renders e.g. ``9.7e+07`` for a chr-1 gene at ~97 Mb,
-        # which is hard to read and ambiguous (Mb? kb? bp?).
+        # Show distance from gene start in the unit that best fits the
+        # viewing window:
+        #   <  5 kb span   → bp        (tight zoom: a single peak / small gene)
+        #   5 kb – 1 Mb    → kb        (normal gene scale)
+        #   >= 1 Mb        → Mb        (very long genes; keeps ticks short)
+        # Anchoring the axis at gene_start (so it reads 0 → gene_length)
+        # avoids the cognitive trap of seeing absolute coordinates like
+        # ``155,276 kb`` and mistaking the view for a chromosome-scale
+        # window.  Absolute coordinates remain in the figure title for IGV
+        # / UCSC cross-reference.
         bottom_ax = axes[-1]
+        gene_anchor = x_lo
         if gene_span >= 1_000_000:
-            unit_label, unit_div = "Mb", 1_000_000
-            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
-                lambda x, _: f"{x / unit_div:,.2f}"
-            )
-        elif gene_span >= 1_000:
-            unit_label, unit_div = "kb", 1_000
-            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
-                lambda x, _: f"{x / unit_div:,.1f}"
-            )
+            unit_label, unit_div, fmt_str = "Mb", 1_000_000, "{val:,.2f}"
+        elif gene_span >= 5_000:
+            unit_label, unit_div, fmt_str = "kb", 1_000, "{val:,.1f}"
         else:
-            unit_label = "bp"
-            tick_fmt = matplotlib.ticker.FuncFormatter(  # type: ignore[attr-defined]
-                lambda x, _: f"{int(x):,}"
-            )
-        bottom_ax.xaxis.set_major_formatter(tick_fmt)
+            unit_label, unit_div, fmt_str = "bp", 1, "{val:,.0f}"
+
+        def _format_tick(x: float, _: int) -> str:
+            return fmt_str.format(val=(x - gene_anchor) / unit_div)
+
+        bottom_ax.xaxis.set_major_formatter(
+            matplotlib.ticker.FuncFormatter(_format_tick)  # type: ignore[attr-defined]
+        )
         bottom_ax.set_xlabel(
-            f"Genomic position on chr{panel.chrom} ({unit_label})",
+            f"Distance from gene start ({unit_label})  "
+            f"— anchor chr{panel.chrom}:{gene_anchor:,}",
             fontsize=9,
         )
         bottom_ax.tick_params(axis="x", labelsize=7)
 
         # --- figure title ---
+        # Make the gene-scope explicit:
+        #   1. lead with the gene symbol (e.g. "CLIC2") when available, so the
+        #      reader immediately sees this is a one-gene view, not a region
+        #      or chromosome view;
+        #   2. include the Ensembl ID in parens for unambiguous lookup;
+        #   3. show absolute genomic range AND gene length in a matching
+        #      unit so the axis below (0..gene_length) is anchored to a
+        #      concrete coordinate.
         n_pas = len(panel.pas_ids)
+        if gene_span >= 1_000_000:
+            length_str = f"{gene_span / 1_000_000:,.2f} Mb"
+        elif gene_span >= 1_000:
+            length_str = f"{gene_span / 1_000:,.1f} kb"
+        else:
+            length_str = f"{gene_span:,} bp"
+        if panel.gene_name:
+            gene_label = f"{panel.gene_name} ({panel.gene_id})"
+        else:
+            gene_label = panel.gene_id
         title = (
-            f"Gene {panel.gene_id} — "
-            f"{panel.chrom}:{panel.start}-{panel.end} "
-            f"({'−' if panel.strand == '-' else '+'} strand) — "
-            f"{n_pas} PAS"
+            f"Gene {gene_label} — "
+            f"chr{panel.chrom}:{panel.start:,}-{panel.end:,} "
+            f"({'−' if panel.strand == '-' else '+'} strand, "
+            f"{length_str}) — {n_pas} PAS"
         )
         fig.suptitle(title, fontsize=9, y=1.01)
 
@@ -321,10 +344,14 @@ class GeneTrackMatplotlib(VizStrategy):
                     "within-gene proportions."
                 ),
                 "gene_id": panel.gene_id,
+                "gene_name": panel.gene_name,
                 "chrom": panel.chrom,
                 "start": panel.start,
                 "end": panel.end,
                 "strand": panel.strand,
+                "view_start": int(x_lo),
+                "view_end": int(x_hi),
+                "view_unit": unit_label,
                 "n_pas": n_pas,
                 "n_clusters_rendered": n_clusters_rendered,
                 "n_isoforms": n_isoforms,
@@ -372,6 +399,14 @@ def _draw_gene_structure(
 ) -> None:
     """Draw exon bars and intron lines for each isoform.
 
+    The exon boxes are drawn at the GTF coordinates exactly, BUT clamped to
+    a minimum visible width of ~0.4% of the view span so that small exons
+    (commonly 80–200 bp on a 50–900 kb gene = 0.1–0.4% of axis width)
+    don't render as 1-pixel slivers and disappear visually.  The intron
+    backbone behind them is at true coordinates, so the visual lengthening
+    only widens the exon box around its true left edge and has no impact
+    on PAS positions or anything else.
+
     Args:
         ax: Matplotlib Axes to draw into.
         panel: GenePanel with isoforms field.
@@ -381,6 +416,9 @@ def _draw_gene_structure(
     exon_colour = "#4477aa"
     intron_colour = "#888888"
     exon_height = 0.6  # fraction of the row height
+
+    view_span = max(x_max - x_min, 1)
+    min_visible_exon_w = max(view_span * 0.004, 1)
 
     for row_idx, (tid, exons) in enumerate(panel.isoforms):
         y_centre = row_idx + 0.5
@@ -413,11 +451,13 @@ def _draw_gene_structure(
                 ),
             )
 
-        # Draw exon rectangles.
+        # Draw exon rectangles.  Visual width is clamped up to a minimum so
+        # tiny exons remain visible; actual coordinates are unaltered.
         for exon_start, exon_end in exons:
+            visual_width = max(exon_end - exon_start, min_visible_exon_w)
             rect = mpatches.FancyBboxPatch(
                 (exon_start, y_centre - exon_height / 2),
-                exon_end - exon_start,
+                visual_width,
                 exon_height,
                 boxstyle="square,pad=0",
                 facecolor=exon_colour,
@@ -474,12 +514,14 @@ def _annotate_pas_positions(
 
     for pas_id, left, width in zip(panel.pas_ids, pas_left_edges, pas_widths):
         # Shaded stripe spanning the PAS's actual genomic extent across
-        # every isoform row.  Alpha is intentionally low so the underlying
-        # exon/intron structure remains visible.
+        # every isoform row.  Low alpha so the underlying exon/intron
+        # structure stays visible (especially small 80–200 bp exons that
+        # the GTF parser correctly draws but which can otherwise get
+        # washed out under the PAS tint).
         ax.axvspan(
             left, left + width,
             ymin=0.0, ymax=1.0,
-            color=pas_colour, alpha=0.18, lw=0,
+            color=pas_colour, alpha=0.10, lw=0,
             zorder=4,
         )
         # Tick mark + pas_id label above the structure track.

--- a/ema/viz/gene_track_matplotlib.py
+++ b/ema/viz/gene_track_matplotlib.py
@@ -112,8 +112,22 @@ class GeneTrackMatplotlib(VizStrategy):
         x_min = panel.start - pad
         x_max = panel.end + pad
 
-        # Bar width = 1% of gene span (minimum 1 bp).
-        bar_w = max(int(gene_span * 0.01), 1)
+        # Minimum visible bar width = 0.5% of gene span (so 1-bp PAS don't
+        # disappear when the gene span is large).  Actual PAS widths from
+        # ``pas_starts``/``pas_ends`` are used otherwise so a 200-bp merged
+        # PAS visibly differs from a 50-bp singleton.
+        min_visible_w = max(int(gene_span * 0.005), 1)
+        # Per-PAS widths, with sensible fallbacks if the helper didn't
+        # populate pas_starts/pas_ends (legacy panels).
+        if panel.pas_starts and panel.pas_ends and len(panel.pas_starts) == len(panel.pas_positions):
+            pas_widths = [
+                max(int(e - s), min_visible_w)
+                for s, e in zip(panel.pas_starts, panel.pas_ends)
+            ]
+            pas_left_edges = list(panel.pas_starts)
+        else:
+            pas_widths = [min_visible_w] * len(panel.pas_positions)
+            pas_left_edges = [int(p) - min_visible_w // 2 for p in panel.pas_positions]
 
         # Subplot heights in order: [gene_structure (optional), cluster0, cluster1, ...]
         subplot_heights: list[float] = []
@@ -142,6 +156,9 @@ class GeneTrackMatplotlib(VizStrategy):
             ax_struct = axes[ax_idx]
             ax_idx += 1
             _draw_gene_structure(ax_struct, panel, x_min, x_max, n_isoforms)
+            _annotate_pas_positions(
+                ax_struct, panel, pas_left_edges, pas_widths, n_isoforms,
+            )
 
         # --- 2. per-cluster coverage rows ---
         # Cap the reads_per_cell y-axis at 95th-pctile × 1.1 across all rendered
@@ -165,8 +182,14 @@ class GeneTrackMatplotlib(VizStrategy):
             rpc_row = panel.reads_per_cell[ci]          # shape: (n_pas,)
             prop_row = panel.proportions[ci]             # shape: (n_pas,)
 
-            for j, (pos, rpc, prop) in enumerate(
-                zip(panel.pas_positions, rpc_row, prop_row)
+            for j, (pos, left_edge, width, rpc, prop) in enumerate(
+                zip(
+                    panel.pas_positions,
+                    pas_left_edges,
+                    pas_widths,
+                    rpc_row,
+                    prop_row,
+                )
             ):
                 # colour by within-gene proportion (NaN → grey)
                 if np.isfinite(prop):
@@ -175,16 +198,19 @@ class GeneTrackMatplotlib(VizStrategy):
                     colour = "#aaaaaa"
 
                 bar_height = float(rpc) if np.isfinite(rpc) and rpc > 0 else 0.0
+                # Draw bar at the PAS's actual genomic span (left edge +
+                # width) so wide merged PAS show as wide bars.
                 ax.bar(
-                    pos,
+                    left_edge,
                     bar_height,
-                    width=bar_w,
+                    width=width,
+                    align="edge",
                     color=colour,
                     linewidth=0,
                     zorder=2,
                 )
 
-                # Proportion annotation on top of bar (skip NaN).
+                # Proportion annotation centred above the bar (skip NaN).
                 if np.isfinite(prop) and bar_height > 0:
                     pct_str = f"{prop * 100:.0f}%"
                     ax.annotate(
@@ -383,3 +409,49 @@ def _draw_gene_structure(
     ax.spines["left"].set_visible(False)
     ax.set_ylabel("Isoforms", fontsize=7, labelpad=4)
     ax.tick_params(axis="x", bottom=False)
+
+
+def _annotate_pas_positions(
+    ax: "plt.Axes",  # type: ignore[name-defined]
+    panel: Any,
+    pas_left_edges: list[int],
+    pas_widths: list[int],
+    n_isoforms: int,
+) -> None:
+    """Overlay each PAS region as a coloured stripe + pas_id tick on the structure axis.
+
+    Makes the actual genomic position (and width, post-merger) of every PAS
+    visible against the isoform structure --- the user can immediately see
+    which exon / 3'UTR each PAS sits in, and whether two PAS shown side-by-
+    side in the coverage rows are genuinely close on the genome or just
+    appear close because the rendered bars are clipped to a small axis.
+
+    Args:
+        ax: The gene-structure subplot axes.
+        panel: GenePanel with ``pas_ids`` aligned to ``pas_left_edges``.
+        pas_left_edges: Genomic left-edge of each PAS region.
+        pas_widths: Width (bp) of each PAS region.
+        n_isoforms: Isoform row count (used to size annotations).
+    """
+    pas_colour = "#C44E52"     # warm red — high-contrast against blue exons
+    label_y = n_isoforms + 0.05
+
+    for pas_id, left, width in zip(panel.pas_ids, pas_left_edges, pas_widths):
+        # Shaded stripe spanning the PAS's actual genomic extent across
+        # every isoform row.  Alpha is intentionally low so the underlying
+        # exon/intron structure remains visible.
+        ax.axvspan(
+            left, left + width,
+            ymin=0.0, ymax=1.0,
+            color=pas_colour, alpha=0.18, lw=0,
+            zorder=4,
+        )
+        # Tick mark + pas_id label above the structure track.
+        centre = left + width / 2.0
+        ax.text(
+            centre, label_y,
+            f"{pas_id}",
+            ha="center", va="bottom",
+            fontsize=5, color=pas_colour,
+            rotation=0, clip_on=False,
+        )

--- a/ema/viz/gene_track_plotly.py
+++ b/ema/viz/gene_track_plotly.py
@@ -356,6 +356,22 @@ class GeneTrackPlotly(VizStrategy):
         y_vals: list[float] = panel.reads_per_cell[ci, :].tolist()
         proportions_row = panel.proportions[ci, :]
 
+        # Per-bar widths from actual PAS spans so wide merged PAS show as
+        # wide bars.  Fall back to a small fixed width (0.5% of gene span,
+        # min 1 bp) when pas_starts/pas_ends aren't populated.
+        gene_span = max(panel.end - panel.start, 1)
+        min_w = max(int(gene_span * 0.005), 1)
+        if (
+            panel.pas_starts and panel.pas_ends
+            and len(panel.pas_starts) == n_pas
+        ):
+            bar_widths: list[int] = [
+                max(int(e - s), min_w)
+                for s, e in zip(panel.pas_starts, panel.pas_ends)
+            ]
+        else:
+            bar_widths = [min_w] * n_pas
+
         # Build custom_data columns aligned with each bar.
         custom_data: list[list[Any]] = []
         for j in range(n_pas):
@@ -381,6 +397,7 @@ class GeneTrackPlotly(VizStrategy):
             go.Bar(
                 x=x_vals,
                 y=y_vals,
+                width=bar_widths,
                 customdata=custom_data,
                 hovertemplate=(
                     "<b>PAS %{customdata[0]}</b><br>"

--- a/ema/viz/proportion_heatmap_matplotlib.py
+++ b/ema/viz/proportion_heatmap_matplotlib.py
@@ -38,24 +38,29 @@ def _build_pas_cluster_matrix(
     adata,
     cluster_key: str,
     top_n: int,
-) -> tuple[pd.DataFrame, list[str]] | tuple[None, None]:
-    """Return (pas x cluster mean proportion table, sorted cluster labels).
+) -> tuple[pd.DataFrame, list[str], pd.DataFrame] | tuple[None, None, None]:
+    """Return (pas x cluster mean proportion table, sorted cluster labels, pos meta).
 
-    Returns ``(None, None)`` if the inputs lack the columns we need.
+    Returns ``(None, None, None)`` if the inputs lack the columns we need.
+
+    The returned position metadata has one row per PAS surviving the
+    top-N variance cut, with columns ``pas_id, gene_id, chrom, start, end,
+    strand``.  Used by the caller to label rows with genomic coordinates
+    and to insert gene separator lines on the heatmap.
     """
     if "proportion" not in pdui_df.columns or "cell" not in pdui_df.columns:
-        return None, None
+        return None, None, None
     if "pas_id" not in pdui_df.columns:
-        return None, None
+        return None, None, None
     if cluster_key not in adata.obs.columns:
-        return None, None
+        return None, None, None
 
     cell_to_cluster = adata.obs[cluster_key].astype(str).to_dict()
     df = pdui_df.dropna(subset=["proportion"]).copy()
     df["cluster"] = df["cell"].map(cell_to_cluster)
     df = df.dropna(subset=["cluster"])
     if df.empty:
-        return None, None
+        return None, None, None
 
     # Mean proportion per (pas_id, cluster)
     pivot = (
@@ -67,12 +72,43 @@ def _build_pas_cluster_matrix(
     variances = pivot.var(axis=1, skipna=True).fillna(0.0)
     top_idx = variances.sort_values(ascending=False).head(top_n).index
     pivot = pivot.loc[top_idx]
+
     cluster_order = sorted(
         pivot.columns.tolist(),
         key=lambda x: int(x) if str(x).isdigit() else x,
     )
     pivot = pivot[cluster_order]
-    return pivot, cluster_order
+
+    # Position metadata for each surviving pas_id (one row per pas_id).
+    pos_cols = [c for c in ("gene_id", "chrom", "start", "end", "strand")
+                if c in pdui_df.columns]
+    if pos_cols:
+        pos_meta = (
+            pdui_df[["pas_id"] + pos_cols]
+            .drop_duplicates(subset=["pas_id"])
+            .set_index("pas_id")
+            .reindex(pivot.index)
+            .reset_index()
+        )
+    else:
+        pos_meta = pd.DataFrame({"pas_id": pivot.index})
+
+    # Re-order rows: group by gene_id, ascending start position within each
+    # gene.  Genes themselves are ordered by their first-occurring PAS in
+    # the original variance ranking — preserves "most-interesting-first"
+    # while keeping same-gene PAS contiguous.
+    if "gene_id" in pos_meta.columns and "start" in pos_meta.columns:
+        # gene order = order of first appearance in the (already variance-
+        # sorted) pivot index
+        pos_meta["_gene_rank"] = (
+            pos_meta["gene_id"].map(
+                {g: i for i, g in enumerate(pos_meta["gene_id"].drop_duplicates())}
+            )
+        )
+        pos_meta = pos_meta.sort_values(["_gene_rank", "start"]).drop(columns="_gene_rank")
+        pivot = pivot.loc[pos_meta["pas_id"].tolist()]
+
+    return pivot, cluster_order, pos_meta
 
 
 @register_viz_strategy
@@ -102,7 +138,7 @@ class ProportionHeatmapMatplotlib(VizStrategy):
             pdui_df, adata = data
             cluster_key, top_n = "leiden", 50
 
-        pivot, clusters = _build_pas_cluster_matrix(
+        pivot, clusters, pos_meta = _build_pas_cluster_matrix(
             pdui_df, adata, cluster_key, top_n,
         )
         if pivot is None or pivot.empty:
@@ -114,30 +150,88 @@ class ProportionHeatmapMatplotlib(VizStrategy):
 
         # Display values in [0, 1]; clip strictly to avoid color flicker on NaN.
         mat = pivot.fillna(0.0).values
-        fig_h = max(5, 0.18 * pivot.shape[0])
-        fig_w = max(5, 0.8 * pivot.shape[1] + 2)
+        # Slightly more vertical room per row so the longer (pas | gene |
+        # chr:start-end) labels stay readable.
+        fig_h = max(5, 0.24 * pivot.shape[0])
+        fig_w = max(7, 0.8 * pivot.shape[1] + 4)
         fig, ax = plt.subplots(figsize=(fig_w, fig_h))
         im = ax.imshow(mat, aspect="auto", cmap="viridis", vmin=0.0, vmax=1.0)
 
         ax.set_xticks(range(len(clusters)))
         ax.set_xticklabels(clusters)
         ax.set_xlabel("cluster")
-        # Only annotate row labels when readable (<= 50 rows).
-        if pivot.shape[0] <= 50:
+
+        # Build informative y-labels: "pas_id  GENE  chrN:start-end (strand)".
+        # When position metadata is missing we fall back to bare pas_id, which
+        # reproduces the legacy behaviour.
+        def _format_row(pas_id, row) -> str:
+            parts = [str(pas_id)]
+            if "gene_id" in row and pd.notna(row.get("gene_id")):
+                parts.append(str(row["gene_id"]))
+            if (
+                "chrom" in row and "start" in row and "end" in row
+                and pd.notna(row.get("chrom"))
+            ):
+                strand = row.get("strand", "")
+                strand_str = f" ({strand})" if isinstance(strand, str) and strand else ""
+                parts.append(
+                    f"chr{row['chrom']}:{int(row['start']):,}-{int(row['end']):,}"
+                    f"{strand_str}"
+                )
+            return "  ".join(parts)
+
+        if pivot.shape[0] <= 50 and pos_meta is not None and not pos_meta.empty:
             ax.set_yticks(range(pivot.shape[0]))
-            ax.set_yticklabels([str(p) for p in pivot.index])
+            pos_by_pas = pos_meta.set_index("pas_id")
+            labels = [
+                _format_row(p, pos_by_pas.loc[p] if p in pos_by_pas.index else {})
+                for p in pivot.index
+            ]
+            ax.set_yticklabels(labels, fontsize=7, family="monospace")
+        elif pivot.shape[0] <= 50:
+            ax.set_yticks(range(pivot.shape[0]))
+            ax.set_yticklabels([str(p) for p in pivot.index], fontsize=7)
         else:
             ax.set_yticks([])
-        ax.set_ylabel(f"PAS (top-{pivot.shape[0]} by variance)")
+
+        # Insert separator lines between gene groups so same-gene rows
+        # group visually.  Skips when no gene metadata is available.
+        if (
+            pos_meta is not None
+            and "gene_id" in pos_meta.columns
+            and pivot.shape[0] >= 2
+        ):
+            ordered_genes = pos_meta["gene_id"].tolist()
+            for i in range(1, len(ordered_genes)):
+                if ordered_genes[i] != ordered_genes[i - 1]:
+                    ax.axhline(
+                        y=i - 0.5, color="#FFFFFF", lw=0.8, alpha=0.85,
+                    )
+
+        ax.set_ylabel(
+            f"PAS (top-{pivot.shape[0]} by variance, grouped by gene & "
+            f"sorted by genomic position)"
+        )
         ax.set_title("Mean PAS proportion per cluster")
         fig.colorbar(im, ax=ax, label="mean proportion")
 
         paths = save_matplotlib(fig, output_basepath)
+        n_genes = (
+            int(pos_meta["gene_id"].nunique())
+            if pos_meta is not None and "gene_id" in pos_meta.columns
+            else None
+        )
         write_figure_meta(output_basepath, {
             "viz_strategy": self.name,
             "cluster_key": cluster_key,
             "n_pas_shown": int(pivot.shape[0]),
             "n_clusters": int(pivot.shape[1]),
+            "n_genes": n_genes,
             "top_n_selected_by": "cross-cluster variance",
+            "row_order": (
+                "grouped by gene_id (variance-rank first PAS), "
+                "within-gene by genomic start"
+            ),
+            "y_label_format": "pas_id  gene_id  chrN:start-end (strand)",
         })
         return paths

--- a/tests/test_pas_merge.py
+++ b/tests/test_pas_merge.py
@@ -1,0 +1,204 @@
+"""Unit tests for the strategy-agnostic post-detection PAS merger.
+
+Covers both tiers and the strategy-driven valley threshold:
+    Tier 1: ``min_pas_spacing`` distance floor
+    Tier 2: valley vs ``strategy.valley_threshold(peak, min_pas_prominence)``
+"""
+from __future__ import annotations
+
+import pytest
+
+from ema.strategies.utils import merge_close_or_low_prominence
+
+
+class _StubPeak:
+    """Minimal Peak stand-in exposing only what the merger needs."""
+
+    def __init__(self, peak_list):
+        self.peak_list = peak_list
+
+
+class _StaticStrategy:
+    """Non-lambda strategy: valley threshold == user setting."""
+
+    def valley_threshold(self, peak, user_min_pas_prominence):
+        return float(user_min_pas_prominence)
+
+
+class _LambdaLikeStrategy:
+    """Lambda strategy: valley threshold == fixed lambda value (here: 10)."""
+
+    def __init__(self, lambda_value: float = 10.0):
+        self.lambda_value = lambda_value
+
+    def valley_threshold(self, peak, user_min_pas_prominence):
+        return float(self.lambda_value)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_passes_through():
+    peak = _StubPeak([])
+    assert merge_close_or_low_prominence([], peak, _StaticStrategy(), 100, 5.0) == []
+
+
+def test_single_region_passes_through():
+    peak = _StubPeak([(100, 50)])
+    assert merge_close_or_low_prominence(
+        [(50, 150)], peak, _StaticStrategy(), 100, 5.0
+    ) == [(50, 150)]
+
+
+def test_both_tiers_disabled_returns_input_unchanged():
+    """min_pas_spacing=0 and min_pas_prominence<0 → full no-op (baseline)."""
+    peak = _StubPeak([(p, 30) for p in range(0, 200)])
+    regions = [(0, 10), (11, 20), (50, 60)]
+    out = merge_close_or_low_prominence(regions, peak, _StaticStrategy(), 0, -1.0)
+    assert out == regions
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: distance floor
+# ---------------------------------------------------------------------------
+
+
+def test_tier1_merges_close_pair_unconditionally():
+    """1-bp gap < min_pas_spacing=50 → merge even if valley would not trigger Tier 2."""
+    # Heights are all 100, so any valley would be 100 — well above threshold.
+    peak = _StubPeak([(p, 100) for p in range(0, 200)])
+    regions = [(50, 100), (101, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=50, min_pas_prominence=5.0,
+    )
+    assert out == [(50, 150)]
+
+
+def test_tier1_keeps_far_pair_when_tier2_passes():
+    """Gap of 100 bp ≥ spacing=50; valley is high → Tier 2 passes → keep both."""
+    peak = _StubPeak([(p, 100) for p in range(0, 300)])
+    regions = [(50, 100), (200, 250)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=50, min_pas_prominence=5.0,
+    )
+    assert out == regions
+
+
+def test_tier1_disabled_when_spacing_zero():
+    """spacing=0 → Tier 1 inactive, Tier 2 still applies."""
+    peak = _StubPeak([(p, 100) for p in range(0, 200)])
+    regions = [(50, 100), (101, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=0, min_pas_prominence=5.0,
+    )
+    # Tier 1 off; valley is empty (no positions strictly between 100 and 101)
+    # → _min_h_between returns 0 → 0 < 5 → merge by Tier 2.
+    assert out == [(50, 150)]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: static threshold (non-lambda strategy)
+# ---------------------------------------------------------------------------
+
+
+def test_tier2_static_merges_shallow_valley():
+    """Valley = 3, threshold = 5 → merge."""
+    heights = [(p, 100) for p in range(0, 60)] \
+              + [(p, 3) for p in range(60, 70)] \
+              + [(p, 100) for p in range(70, 200)]
+    peak = _StubPeak(heights)
+    regions = [(0, 60), (70, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=0, min_pas_prominence=5.0,
+    )
+    assert out == [(0, 150)]
+
+
+def test_tier2_static_keeps_deep_valley():
+    """Valley = 20, threshold = 5 → keep separate."""
+    heights = [(p, 100) for p in range(0, 60)] \
+              + [(p, 20) for p in range(60, 70)] \
+              + [(p, 100) for p in range(70, 200)]
+    peak = _StubPeak(heights)
+    regions = [(0, 60), (70, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=0, min_pas_prominence=5.0,
+    )
+    assert out == regions
+
+
+def test_tier2_disabled_when_prominence_negative():
+    """min_pas_prominence=-1 → Tier 2 off."""
+    heights = [(p, 100) for p in range(0, 200)]
+    peak = _StubPeak(heights)
+    regions = [(0, 60), (70, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(), min_pas_spacing=200, min_pas_prominence=-1.0,
+    )
+    # Tier 1 fires because gap 10 < 200 → merge.
+    assert out == [(0, 150)]
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: dynamic threshold (lambda-like strategy)
+# ---------------------------------------------------------------------------
+
+
+def test_tier2_lambda_uses_strategy_threshold_not_user_setting():
+    """Lambda strategy returns 10; valley = 8 → merge (8 < 10) regardless of user value."""
+    heights = [(p, 100) for p in range(0, 60)] \
+              + [(p, 8) for p in range(60, 70)] \
+              + [(p, 100) for p in range(70, 200)]
+    peak = _StubPeak(heights)
+    regions = [(0, 60), (70, 150)]
+    # User sets min_pas_prominence=5 (would not merge with static), but the
+    # lambda strategy overrides to 10 → valley 8 < 10 → merge.
+    out = merge_close_or_low_prominence(
+        regions, peak, _LambdaLikeStrategy(10.0),
+        min_pas_spacing=0, min_pas_prominence=5.0,
+    )
+    assert out == [(0, 150)]
+
+
+def test_tier2_lambda_keeps_valley_above_lambda():
+    """Lambda = 10; valley = 50 → keep."""
+    heights = [(p, 100) for p in range(0, 60)] \
+              + [(p, 50) for p in range(60, 70)] \
+              + [(p, 100) for p in range(70, 200)]
+    peak = _StubPeak(heights)
+    regions = [(0, 60), (70, 150)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _LambdaLikeStrategy(10.0),
+        min_pas_spacing=0, min_pas_prominence=999.0,  # would force merge if static
+    )
+    assert out == regions
+
+
+# ---------------------------------------------------------------------------
+# Chains
+# ---------------------------------------------------------------------------
+
+
+def test_three_way_chain_collapses_to_one():
+    """A → B by Tier 1; (A∪B) → C by Tier 1 → single merged region."""
+    peak = _StubPeak([(p, 100) for p in range(0, 200)])
+    regions = [(0, 30), (31, 60), (61, 90)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(),
+        min_pas_spacing=50, min_pas_prominence=-1.0,  # Tier 2 disabled
+    )
+    assert out == [(0, 90)]
+
+
+def test_unsorted_input_is_sorted_before_merging():
+    """Input regions in reverse order still merge correctly."""
+    peak = _StubPeak([(p, 100) for p in range(0, 200)])
+    regions = [(100, 150), (0, 50)]
+    out = merge_close_or_low_prominence(
+        regions, peak, _StaticStrategy(),
+        min_pas_spacing=100, min_pas_prominence=-1.0,
+    )
+    # After sort: [(0,50), (100,150)] — gap 50 < 100 → merge.
+    assert out == [(0, 150)]


### PR DESCRIPTION
## Summary

Adds a strategy-agnostic two-tier merger that runs **after** every
`strategy.find_pas(peak)` call at the caller layer. Fixes the lambda_gradient
twin-PAS artefact (371 same-strand pairs at 1-bp gap on the v9 reference run)
without touching any strategy's internals.

- **Tier 1 — distance gate** (`--min-pas-spacing`). Adjacent regions with
  gap < threshold are merged unconditionally. Default `-1` auto-detects the
  median read length per BAM (98 bp for SRR8325947); summits closer than one
  aligned read length cannot be resolved by short reads.
- **Tier 2 — strategy-driven valley** (`--min-pas-prominence`). New
  `PeakFinderStrategy.valley_threshold(peak, user_setting)` method.
  `lambda_poisson` / `lambda_gradient` override to return their own
  `compute_lambda(heights)` — fully dynamic, in lock-step with the
  strategy's significance gate. `original` / `sierra_iterative` use the
  static user setting (default 5.0). Merge when `valley < threshold`.

Reads inside the merged span are absorbed automatically — `cb_positions` is
dense across the parent peak, and `reconstruct_cb_dict` slices by inclusive
range. No explicit summing code is needed.

## Why this design

| Failure mode | Caught upstream by | Caught by this PR |
|---|---|---|
| Twin summits (1-bp partition split inside one peak) | nothing | Tier 1 |
| Shoulder summits with valley at lambda | nothing | Tier 2 (lambda) |
| Distinct peaks across read clusters | `merge_len` | n/a |
| Cross-dataset BED merging | `pas_gap` | n/a |

`--merge-len` and `--pas-gap` operate at different stages and don't catch
within-peak summit spacing. The merger lives at the caller layer in
`peackcalling.py` so every strategy (current and future) benefits with no
per-strategy plumbing.

## Wiring (all three live paths)

- **Monolithic** (`peackcalling.py`, default sequential): 5 `find_pas` call
  sites with the merger one-liner; auto-detect after BAM open; forwarding to
  tile/pipeline dispatchers.
- **Pipeline** (`peak_pipeline.py`, `--pipeline`): merger inside
  `writer_loop` and `_flush_peak`; sentinel resolved before subprocess spawn.
- **Tile** (`tile_runner.py`, `--tiles`): `JobSpec` carries both params;
  sentinel resolved once at pool startup so workers don't re-scan headers.

## Effect on the v9 lambda_gradient reference run (SRR8325947)

| Metric | Before | After | Δ |
|---|---|---|---|
| Total PAS | 15,948 | 15,568 | **−380** |
| Close pairs <30 bp | 371 | **0** | −371 |
| Filtered cells | 752 | 752 | 0 |
| Leiden clusters | 11 | 11 | 0 |
| Genes (classic length) | 1,925 | 1,898 | −27 |
| Genes (proportion length) | 5,339 | 5,407 | **+68** |
| Genes (shannon entropy) | 5,339 | 5,407 | **+68** |

Classic drops 27 genes that became single-PAS after merging.
Proportion/shannon **gain** 68 genes — when twin PAS that straddled gene
boundaries are merged into one wider region, gene assignment becomes
unambiguous and the gene becomes eligible for analysis.

## Validation

- **13 unit tests** (`tests/test_pas_merge.py`): both tiers, lambda override,
  distance floor, three-way chains, empty/single/unsorted inputs. All pass.
- **All 4 strategies × full BAM × merger ON**: zero close pairs <30 bp.
  - `original`: 32,024 PAS
  - `lambda_poisson`: 15,568 PAS
  - `lambda_gradient`: 15,568 PAS
  - `sierra_iterative`: 44,065 PAS
- **Pipeline ≡ Monolithic** on chr22 `lambda_gradient`: bit-identical 252-PAS
  output (same coords + strand).
- **665 of 668** existing tests still pass; the 3 failures are pre-existing
  (verified by stash test) and unrelated to this branch.

## Configuration

```yaml
# defaults (recommended)
min_pas_spacing: -1        # auto = median read length per BAM
min_pas_prominence: 5.0    # ignored by lambda strategies; static for others

# disable Tier 1 only
min_pas_spacing: 0

# disable Tier 2 only
min_pas_prominence: -1

# baseline (no merging at all — bit-exact pre-merger behaviour)
min_pas_spacing: 0
min_pas_prominence: -1
```

CLI equivalents: `--min-pas-spacing N`, `--min-pas-prominence X`.

## Docs + report

- New `docs/strategies/pas-merger.md` page (in mkdocs nav between
  peak-calling and clustering).
- `docs/cli/run.md` updated with the two new flags.
- Technical report: new Section 5 *Post-Detection PAS-Summit Merger* with
  a 3-panel explainer figure (`reports/figures/pas_merge_explainer.png`)
  and updated Table 6 stats.

## Test plan

- [x] `uv run pytest tests/test_pas_merge.py -v` (13/13 pass)
- [x] `uv run pytest tests/` (665 pass; 3 pre-existing failures unrelated)
- [x] Full `ema run` on SRR8325947 with `lambda_gradient` + new merger:
      output validated; downstream switch_diff / length / geneview
      regenerated and figures embedded in technical report
- [x] 4-strategy smoke on full BAM, all 0 close pairs after merge
- [x] Pipeline vs monolithic equivalence on chr22 lambda_gradient
- [ ] CI green on develop merge (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)